### PR TITLE
feat: display warning and reject if eeot > eot

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,12 @@
                 // Add eager eot threshold if specified
                 const eagerEotThreshold = this.elements.eagerEotThreshold.value;
                 if (eagerEotThreshold) {
+                    if (eagerEotThreshold > (this.elements.eotThreshold.value || 0.7)) {
+                        this.log('❌ Eager End-of-Turn Threshold must be below End-of-Turn Threshold');
+                        this.updateStatus('disconnected', 'Disconnected');
+                        this.elements.connectBtn.disabled = false;
+                        return;
+                    }
                     params.append('eager_eot_threshold', eagerEotThreshold);
                 }
 


### PR DESCRIPTION


## Code Change Explanation

This code change implements a **validation check for End-of-Turn (EOT) threshold parameters** in what appears to be a voice streaming application using Deepgram's speech recognition service.

**What it does:**

1. **Validates threshold relationship**: It checks that the `eagerEotThreshold` value is **smaller** than the regular `eotThreshold` value (which defaults to 0.7)

2. **Prevents invalid configuration**: If the eager EOT threshold is greater than or equal to the regular EOT threshold, it:
   - Logs an error message: "❌ Eager End-of-Turn Threshold must be below End-of-Turn Threshold"
   - Sets the status to 'disconnected' 
   - Re-enables the connect button
   - Stops the connection process (returns early)

**Why this matters:**

In speech recognition systems, End-of-Turn thresholds determine when the system thinks a speaker has finished talking:

- **Regular EOT Threshold** (0.7 default): Higher confidence threshold for detecting end-of-turn
- **Eager EOT Threshold**: Lower confidence threshold that triggers earlier, allowing for more responsive interruptions

The **eager threshold must be lower** than the regular threshold because:
- It needs to detect potential end-of-turn with less certainty (earlier detection)
- The regular threshold provides a more confident confirmation
- Having eager ≥ regular would break this logical flow

**Next Step**: This validation ensures the voice agent responds appropriately to user speech patterns.  
**Future Steps**: Once valid thresholds are set, the WebSocket connection proceeds to establish streaming audio recognition.