### PR TITLE
feat: persist existing transcript when new turn triggers

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@
                     data.audio_window_start !== undefined && data.audio_window_end !== undefined
                         ? `${data.audio_window_start.toFixed(1)}s - ${data.audio_window_end.toFixed(1)}s`
                         : '-';
-                this.elements.currentTranscript.textContent = data.transcript || 'Waiting for speech...';
+                this.elements.currentTranscript.textContent = data.transcript || this.elements.currentTranscript.textContent;
             }
 
             updateStatus(type, message) {


### PR DESCRIPTION
Purpose: This line prevents the transcript display from being cleared when FLUX API messages don't contain transcript data.

How it works:
Left side: data.transcript - tries to use the transcript from the incoming FLUX message
Fallback: || this.elements.currentTranscript.textContent - if no transcript exists in the message, keeps the current displayed transcript
Why this matters:
FLUX API sends different types of messages (StartOfTurn, Update, EndOfTurn, etc.). Not every message contains transcript text, so without this fallback logic, the transcript display would get cleared whenever a message without transcript data arrives.
Impact

Before: Transcript could disappear during turn transitions or status updates

After: Transcript persists until explicitly updated with new content
User Experience: Smoother, more stable transcript display during real-time speech recognition