### PR TITLE
another attempt to fix routing

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,9 @@ auto_rollback = true
 
 [build]
 
+[env]
+NODE_ENV = "production"
+
 [http_service]
 internal_port = 3000
 auto_stop_machines = "stop"

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
 
                 // Build WebSocket URL with parameters for our local proxy
                 // Auto-detect if we're running under /flux-streaming path
-                const BASE_PATH = location.pathname.startsWith('/flux-streaming') ? '/flux-streaming' : '';
+                const BASE_PATH = (location.pathname === '/flux-streaming' || location.pathname.startsWith('/flux-streaming/')) ? '/flux-streaming' : '';
                 const params = new URLSearchParams({
                     model: 'flux-general-en',
                     sample_rate: '16000',

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const { URL } = require('url');
 const PORT = 3000;
 const BASE_PATH = process.env.NODE_ENV === 'production' ? '/flux-streaming' : '';
 
+
 // Get API key from environment variable
 const DEEPGRAM_API_KEY = process.env.DEEPGRAM_API_KEY;
 


### PR DESCRIPTION
## PR Summary: Fix CSS loading issue with custom app routes

**Problem**: CSS files weren't loading when the app was deployed behind a proxy with custom routing (`https://demos.dx.deepgram.com/flux-streaming`). The absolute CSS path `/styles/deepgram-minimal.css` resolved to the domain root instead of the correct subdirectory path.


Note: #14  didn't fix it. 😢 but that PR handled the CSS routing fix.

**Root Cause**: 
- CSS path resolved to `https://demos.dx.deepgram.com/styles/deepgram-minimal.css` 
- Should resolve to `https://demos.dx.deepgram.com/flux-streaming/styles/deepgram-minimal.css`
- `NODE_ENV=production` wasn't set on Fly.io, so server wasn't handling the `/flux-streaming` prefix correctly

**Solution**:
1. **Fixed CSS path**: Changed to relative path `href="./styles/deepgram-minimal.css"` - works in both dev and production
2. **Fixed server-side BASE_PATH detection**: 
   - `const BASE_PATH = process.env.NODE_ENV === 'production' ? '/flux-streaming' : '';`
   - Added `NODE_ENV = "production"` to `fly.toml`
3. **Fixed client-side BASE_PATH detection**: 
   - `const BASE_PATH = (location.pathname === '/flux-streaming' || location.pathname.startsWith('/flux-streaming/')) ? '/flux-streaming' : '';`
   - Prevents false positives like `/flux-streaming-v2`

**Files Changed**:
- `index.html`: Updated CSS path and WebSocket BASE_PATH detection logic
- `server.js`: Made BASE_PATH environment-dependent  
- `fly.toml`: Added production environment variable

**Testing**: 
- ✅ Local development: `npm start` → `http://localhost:3000` (BASE_PATH = '')
- ✅ Production mode: `NODE_ENV=production npm start` → `http://localhost:3000/flux-streaming` (BASE_PATH = '/flux-streaming')