### PR TITLE
fix: fixes path query issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,7 +71,9 @@ async function testFluxApiConnectivity() {
 
 const server = http.createServer((req, res) => {
   // Simple static file server with base path handling
-  let requestPath = req.url;
+  // Parse URL to separate pathname from query parameters
+  const parsedUrl = new URL(req.url, `http://localhost:${PORT}`);
+  let requestPath = parsedUrl.pathname;
   if (requestPath.startsWith(BASE_PATH)) {
     requestPath = requestPath.substring(BASE_PATH.length);
   }


### PR DESCRIPTION
## PR Summary 

1. **Identified the root cause**: The flux-streaming demo's static file server was incorrectly treating the entire URL (including `_gl` query parameters) as a filename
2. **Fixed the issue**: Modified `/Users/johnvajda/Documents/Github/deepgram-repos/flux-streaming-demo/server.js` to properly parse URLs and separate pathname from query parameters
3. **Explanation**: The `_gl` parameter is a Google Analytics cross-domain tracking parameter that gets added when clicking links from external sources

The fix is now ready in your codebase. When you deploy it to fly.io, the demo should work correctly with Google Analytics tracking parameters.

## Testing

Works with all test routes ✅ 

- https://demos.dx.deepgram.com/flux-streaming
- https://demos.dx.deepgram.com/flux-streaming?
- https://demos.dx.deepgram.com/flux-streaming?_gl=1*36evuq*_gcl_au*MjA3OTExMjA0OC4xNzU5NDI4Njgy*_ga*MTY3OTQ1NTAyNi4xNzU5NDI4NjgyNzU5NDI4Njgy

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211539405087879